### PR TITLE
Don’t show attached plans on the proposal detail page.

### DIFF
--- a/app/views/decidim/proposals/proposals/show.html.erb
+++ b/app/views/decidim/proposals/proposals/show.html.erb
@@ -96,7 +96,6 @@
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <%= linked_resources_for @proposal, :results, "included_proposals" %>
     <%= linked_resources_for @proposal, :projects, "included_proposals" %>
-    <%= linked_resources_for @proposal, :plans, "included_proposals" %>
     <%= linked_resources_for @proposal, :meetings, "proposals_from_meeting" %>
     <%= linked_resources_for @proposal, :proposals, "copied_from_component" %>
 


### PR DESCRIPTION
This was causing an error with loading the proposal page, due to an organization (with no avatar) being attached as the proposal author. We can revisit this later, but it will unblock us on creating example proposals.