### PR TITLE
Add new supported locales and appropriate locale names

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 Decidim.configure do |config|
-  config.application_name = "City of Helsinki participationary platform"
+  config.application_name = "Seattle participatory budgeting"
   config.mailer_sender = Rails.application.config.mailer_sender
 
   # Uncomment this lines to set your preferred locales
-  config.default_locale = :fi
-  config.available_locales = [:fi, :en, :sv]
+  config.default_locale = :en
+  config.available_locales = [:en, "zh-Hant", :ko, "zh-Hans", :so, :es, :tl, :vi, :fi, :sv]
 
   # Geocoder configuration
   #config.geocoder = {

--- a/config/locales/overrides/decidim-core.es.yml
+++ b/config/locales/overrides/decidim-core.es.yml
@@ -1,0 +1,3 @@
+es:
+  locale:
+    name: Español

--- a/config/locales/overrides/decidim-core.ko.yml
+++ b/config/locales/overrides/decidim-core.ko.yml
@@ -1,0 +1,3 @@
+ko:
+  locale:
+    name: 한국어

--- a/config/locales/overrides/decidim-core.so.yml
+++ b/config/locales/overrides/decidim-core.so.yml
@@ -1,0 +1,3 @@
+so:
+  locale:
+    name: Soomaali

--- a/config/locales/overrides/decidim-core.tl.yml
+++ b/config/locales/overrides/decidim-core.tl.yml
@@ -1,0 +1,3 @@
+tl:
+  locale:
+    name: Tagalog

--- a/config/locales/overrides/decidim-core.vi.yml
+++ b/config/locales/overrides/decidim-core.vi.yml
@@ -1,0 +1,3 @@
+vi:
+  locale:
+    name: Tiếng Việt

--- a/config/locales/overrides/decidim-core.zh-Hans.yml
+++ b/config/locales/overrides/decidim-core.zh-Hans.yml
@@ -1,0 +1,3 @@
+zh-Hans:
+  locale:
+    name: 普通话

--- a/config/locales/overrides/decidim-core.zh-Hant.yml
+++ b/config/locales/overrides/decidim-core.zh-Hant.yml
@@ -1,0 +1,3 @@
+zh-Hant:
+  locale:
+    name: 廣東話


### PR DESCRIPTION
I lifted the language names from a [Seattle web page](https://www.seattle.gov/neighborhoods/outreach-and-engagement/lightrail).

This is what it looks like with an organization that is appropriately configured:

<img width="399" alt="Screen Shot 2020-07-15 at 4 53 37 PM" src="https://user-images.githubusercontent.com/37423111/87611153-24b1ba00-c6bc-11ea-89cd-420afd38d683.png">
