### PR TITLE
Add new supported locales and appropriate locale names

### DIFF
--- a/app/assets/javascripts/datepicker-locales/foundation-datepicker.ko.js
+++ b/app/assets/javascripts/datepicker-locales/foundation-datepicker.ko.js
@@ -1,0 +1,14 @@
+/**
+ * Placeholder translation for foundation-datepicker
+ */
+;(function($){
+	$.fn.fdatepicker.dates['ko'] = {
+    days: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
+    months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    today: "Today",
+    weekStart: 1
+  };
+}(jQuery));

--- a/app/assets/javascripts/datepicker-locales/foundation-datepicker.so.js
+++ b/app/assets/javascripts/datepicker-locales/foundation-datepicker.so.js
@@ -1,0 +1,14 @@
+/**
+ * Placeholder translation for foundation-datepicker
+ */
+;(function($){
+	$.fn.fdatepicker.dates['so'] = {
+    days: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
+    months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    today: "Today",
+    weekStart: 1
+  };
+}(jQuery));

--- a/app/assets/javascripts/datepicker-locales/foundation-datepicker.tl.js
+++ b/app/assets/javascripts/datepicker-locales/foundation-datepicker.tl.js
@@ -1,0 +1,14 @@
+/**
+ * Placeholder translation for foundation-datepicker
+ */
+;(function($){
+	$.fn.fdatepicker.dates['tl'] = {
+    days: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
+    months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    today: "Today",
+    weekStart: 1
+  };
+}(jQuery));

--- a/app/assets/javascripts/datepicker-locales/foundation-datepicker.vi.js
+++ b/app/assets/javascripts/datepicker-locales/foundation-datepicker.vi.js
@@ -1,0 +1,14 @@
+/**
+ * Placeholder translation for foundation-datepicker
+ */
+;(function($){
+	$.fn.fdatepicker.dates['vi'] = {
+    days: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
+    months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    today: "Today",
+    weekStart: 1
+  };
+}(jQuery));

--- a/app/assets/javascripts/datepicker-locales/foundation-datepicker.zh-Hans.js
+++ b/app/assets/javascripts/datepicker-locales/foundation-datepicker.zh-Hans.js
@@ -1,0 +1,14 @@
+/**
+ * Placeholder translation for foundation-datepicker
+ */
+;(function($){
+	$.fn.fdatepicker.dates['zh-Hans'] = {
+    days: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
+    months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    today: "Today",
+    weekStart: 1
+  };
+}(jQuery));

--- a/app/assets/javascripts/datepicker-locales/foundation-datepicker.zh-Hant.js
+++ b/app/assets/javascripts/datepicker-locales/foundation-datepicker.zh-Hant.js
@@ -1,0 +1,14 @@
+/**
+ * Placeholder translation for foundation-datepicker
+ */
+;(function($){
+	$.fn.fdatepicker.dates['zh-Hant'] = {
+    days: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
+    months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    today: "Today",
+    weekStart: 1
+  };
+}(jQuery));

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w(admin.js admin.css)
-Rails.application.config.assets.precompile += %w(show-internal-auth.js)
+Rails.application.config.assets.precompile += %w(show-internal-auth.js datepicker-locales/foundation-datepicker.ko.js datepicker-locales/foundation-datepicker.so.js datepicker-locales/foundation-datepicker.tl.js datepicker-locales/foundation-datepicker.vi.js datepicker-locales/foundation-datepicker.zh-Hans.js datepicker-locales/foundation-datepicker.zh-Hant.js)

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 Decidim.configure do |config|
-  config.application_name = "City of Helsinki participationary platform"
+  config.application_name = "Seattle participatory budgeting"
   config.mailer_sender = Rails.application.config.mailer_sender
 
   # Uncomment this lines to set your preferred locales
-  config.default_locale = :fi
-  config.available_locales = [:fi, :en, :sv]
+  config.default_locale = :en
+  config.available_locales = [:en, "zh-Hant", :ko, "zh-Hans", :so, :es, :tl, :vi, :fi, :sv]
 
   # Geocoder configuration
   #config.geocoder = {

--- a/config/locales/overrides/decidim-core.es.yml
+++ b/config/locales/overrides/decidim-core.es.yml
@@ -1,0 +1,3 @@
+es:
+  locale:
+    name: Español

--- a/config/locales/overrides/decidim-core.ko.yml
+++ b/config/locales/overrides/decidim-core.ko.yml
@@ -1,0 +1,3 @@
+ko:
+  locale:
+    name: 한국어

--- a/config/locales/overrides/decidim-core.so.yml
+++ b/config/locales/overrides/decidim-core.so.yml
@@ -1,0 +1,3 @@
+so:
+  locale:
+    name: Soomaali

--- a/config/locales/overrides/decidim-core.tl.yml
+++ b/config/locales/overrides/decidim-core.tl.yml
@@ -1,0 +1,3 @@
+tl:
+  locale:
+    name: Tagalog

--- a/config/locales/overrides/decidim-core.vi.yml
+++ b/config/locales/overrides/decidim-core.vi.yml
@@ -1,0 +1,3 @@
+vi:
+  locale:
+    name: Tiếng Việt

--- a/config/locales/overrides/decidim-core.zh-Hans.yml
+++ b/config/locales/overrides/decidim-core.zh-Hans.yml
@@ -1,0 +1,3 @@
+zh-Hans:
+  locale:
+    name: 普通话

--- a/config/locales/overrides/decidim-core.zh-Hant.yml
+++ b/config/locales/overrides/decidim-core.zh-Hant.yml
@@ -1,0 +1,3 @@
+zh-Hant:
+  locale:
+    name: 廣東話


### PR DESCRIPTION
Add placeholder date picker translation files to work around fatal error when switching to one of the new locales.

I lifted the language names from a [Seattle web page](https://www.seattle.gov/neighborhoods/outreach-and-engagement/lightrail).

This is what it looks like with an organization that is appropriately configured:

<img width="399" alt="Screen Shot 2020-07-15 at 4 53 37 PM" src="https://user-images.githubusercontent.com/37423111/87611153-24b1ba00-c6bc-11ea-89cd-420afd38d683.png">
