### PR TITLE
Fix db:seeds/db:setup to not create plans with organization co-authors

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,3 +10,14 @@
 
 # You can remove the 'faker' gem if you don't want Decidim seeds.
 Decidim.seed!
+
+# The seeds for the decidim-plans gem assigns organizations as plan co-authors
+# which is not possible through the regular website and causes various issues
+# when viewing and editing plans or proposals tied to plans. Let's patch that
+# up for now.
+
+admin = Decidim::User.find_by_email("admin@example.org")
+Decidim::Plans::Plan.all.each do |p|
+  p.coauthorships = []
+  p.add_coauthor(admin)
+end


### PR DESCRIPTION
Realized I never checked this fix in.