### PR TITLE
Admin updates

### DIFF
--- a/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/app/permissions/decidim/proposals/admin/permissions.rb
@@ -58,13 +58,13 @@ module Decidim
           end
   
           def admin_edition_is_available?
-            return true
+            return unless proposal
 
+            true
+            
             # Overriding the existing behavior to always allow editing of proposals by admins.
             # The previous logic is commented out below:
 
-            # return unless proposal
-  
             # (proposal.official? || proposal.official_meeting?) && proposal.votes.empty?
           end
   

--- a/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/app/permissions/decidim/proposals/admin/permissions.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Decidim
+    module Proposals
+      module Admin
+        class Permissions < Decidim::DefaultPermissions
+          def permissions
+            # The public part needs to be implemented yet
+            return permission_action if permission_action.scope != :admin
+  
+            if create_permission_action?
+              # There's no special condition to create proposal notes, only
+              # users with access to the admin section can do it.
+              allow! if permission_action.subject == :proposal_note
+  
+              # Proposals can only be created from the admin when the
+              # corresponding setting is enabled.
+              toggle_allow(admin_creation_is_enabled?) if permission_action.subject == :proposal
+  
+              # Proposals can only be answered from the admin when the
+              # corresponding setting is enabled.
+              toggle_allow(admin_proposal_answering_is_enabled?) if permission_action.subject == :proposal_answer
+            end
+  
+            # Admins can only edit official proposals if they are within the
+            # time limit.
+            allow! if permission_action.subject == :proposal && permission_action.action == :edit && admin_edition_is_available?
+  
+            # Every user allowed by the space can update the category of the proposal
+            allow! if permission_action.subject == :proposal_category && permission_action.action == :update
+  
+            # Every user allowed by the space can import proposals from another_component
+            allow! if permission_action.subject == :proposals && permission_action.action == :import
+  
+            # Every user allowed by the space can merge proposals to another component
+            allow! if permission_action.subject == :proposals && permission_action.action == :merge
+  
+            # Every user allowed by the space can split proposals to another component
+            allow! if permission_action.subject == :proposals && permission_action.action == :split
+  
+            if permission_action.subject == :participatory_texts && participatory_texts_are_enabled?
+              # Every user allowed by the space can manage (import, update and publish) participatory texts to proposals
+              allow! if permission_action.action == :manage
+            end
+  
+            permission_action
+          end
+  
+          private
+  
+          def proposal
+            @proposal ||= context.fetch(:proposal, nil)
+          end
+  
+          def admin_creation_is_enabled?
+            current_settings.try(:creation_enabled?) &&
+              component_settings.try(:official_proposals_enabled)
+          end
+  
+          def admin_edition_is_available?
+            return true
+
+            # Overriding the existing behavior to always allow editing of proposals by admins.
+            # The previous logic is commented out below:
+
+            # return unless proposal
+  
+            # (proposal.official? || proposal.official_meeting?) && proposal.votes.empty?
+          end
+  
+          def admin_proposal_answering_is_enabled?
+            current_settings.try(:proposal_answering_enabled) &&
+              component_settings.try(:proposal_answering_enabled)
+          end
+  
+          def create_permission_action?
+            permission_action.action == :create
+          end
+  
+          def participatory_texts_are_enabled?
+            component_settings.participatory_texts_enabled?
+          end
+        end
+      end
+    end
+  end
+  

--- a/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -73,11 +73,9 @@
       <%= render partial: "decidim/admin/shared/gallery", locals: { form: form } %>
     <% end %>
 
-    <% if @form.equity_composite_index_percentile %>
-        <div class="row column">
-            <%= form.text_field :equity_composite_index_percentile %>
-        </div>
-    <% end %>
+    <div class="row column">
+      <%= form.text_field :equity_composite_index_percentile %>
+    </div>
 
     <% if component_settings.attachments_allowed? %>
       <div class="row column">


### PR DESCRIPTION
All proposals are now editable from the admin portal:
<img width="1213" alt="Screen Shot 2020-07-23 at 4 52 11 PM" src="https://user-images.githubusercontent.com/1252922/88349483-14758c80-cd05-11ea-8ff5-cd048f74feb0.png">

Also, the equity score index is editable, if not previously set:
<img width="354" alt="Screen Shot 2020-07-23 at 4 52 20 PM" src="https://user-images.githubusercontent.com/1252922/88349620-7209d900-cd05-11ea-8c52-e250fb326b4d.png">
