### PR TITLE
Add a flag to organizations controlling whether to show equity impact

### DIFF
--- a/app/cells/decidim/tags_cell.rb
+++ b/app/cells/decidim/tags_cell.rb
@@ -66,7 +66,7 @@ module Decidim
     end
 
     def equity?
-      model.equity_composite_index_percentile != nil
+      current_organization.show_equity_composite_index? && model.equity_composite_index_percentile != nil
     end
 
     def equity_name

--- a/app/commands/concerns/update_organization_overrides.rb
+++ b/app/commands/concerns/update_organization_overrides.rb
@@ -1,0 +1,24 @@
+require 'active_support/concern'
+
+module UpdateOrganizationOverrides
+  extend ActiveSupport::Concern
+
+  included do
+    # Modifies attributes method to add `show_equity_composite_index`
+    def attributes
+      {
+        name: form.name,
+        default_locale: form.default_locale,
+        reference_prefix: form.reference_prefix,
+        twitter_handler: form.twitter_handler,
+        facebook_handler: form.facebook_handler,
+        instagram_handler: form.instagram_handler,
+        youtube_handler: form.youtube_handler,
+        github_handler: form.github_handler,
+        badges_enabled: form.badges_enabled,
+        user_groups_enabled: form.user_groups_enabled,
+        show_equity_composite_index: form.show_equity_composite_index,
+      }.merge(welcome_notification_attributes)
+    end
+  end
+end

--- a/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -16,7 +16,9 @@ module Decidim
         # Available orders based on enabled settings
         def available_orders
           @available_orders ||= begin
-            available_orders = %w(most_equitable random recent)
+            available_orders = []
+            available_orders << "most_equitable" if current_organization.show_equity_composite_index?
+            available_orders << "random" << "recent"
             available_orders << "most_voted" if most_voted_order_available?
             available_orders << "most_endorsed" if current_settings.endorsements_enabled?
             available_orders << "most_commented" if component_settings.comments_enabled?
@@ -29,7 +31,11 @@ module Decidim
           if order_by_votes?
             detect_order("most_voted")
           else
-            "most_equitable"
+            if current_organization.show_equity_composite_index?
+              "most_equitable"
+            end
+
+            "random"
           end
         end
 

--- a/app/forms/concerns/organization_form_extensions.rb
+++ b/app/forms/concerns/organization_form_extensions.rb
@@ -1,0 +1,9 @@
+require 'active_support/concern'
+
+module OrganizationFormExtensions
+  extend ActiveSupport::Concern
+
+  included do
+    attribute :show_equity_composite_index, ActiveRecord::Type::Boolean
+  end
+end

--- a/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -62,10 +62,6 @@ module Decidim
           @scope ||= @scope_id ? current_participatory_space.scopes.find_by(id: @scope_id) : current_participatory_space.scope
         end
 
-        # def equity_composite_index_percentile
-        #   @equity_composite_index_percentile
-        # end
-
         # Scope identifier
         #
         # Returns the scope identifier related to the proposal

--- a/app/presenters/concerns/equity_quintile_presenter_extensions.rb
+++ b/app/presenters/concerns/equity_quintile_presenter_extensions.rb
@@ -7,6 +7,9 @@ module EquityQuintilePresenterExtensions
     def equity_quintile
       (proposal.equity_composite_index_percentile.round(2) * 5).floor() + 1
     end
+
+    def show_equity?
+      proposal.organization.show_equity_composite_index? && proposal.equity_composite_index_percentile != nil
+    end
   end
 end
-  

--- a/app/views/decidim/admin/organization/_form.html.erb
+++ b/app/views/decidim/admin/organization/_form.html.erb
@@ -1,0 +1,75 @@
+<div class="row">
+  <div class="columns xlarge-6">
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="columns xlarge-6">
+    <div class="label--tabs">
+      <label for="organization_social_handlers">
+        <%= t(".social_handlers") %>
+      </label>
+      <ul class="tabs tabs--lang" data-tabs id="organization_social_handlers">
+        <% Decidim::Organization::SOCIAL_HANDLERS.each do |handler| %>
+          <li class="tabs-title <% if handler == Decidim::Organization::SOCIAL_HANDLERS.first %> is-active <% end %>">
+            <a href="#<%= handler %>" <% if handler == Decidim::Organization::SOCIAL_HANDLERS.first %> aria-selected="true" <% end %>>
+              <%= t(".#{handler}") %>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+    <div class="tabs-content" data-tabs-content="organization_social_handlers">
+      <% Decidim::Organization::SOCIAL_HANDLERS.each do |handler| %>
+        <div class="tabs-panel <% if handler == Decidim::Organization::SOCIAL_HANDLERS.first %> is-active <% end %>" id="<%= handler %>">
+          <%= form.text_field "#{handler}_handler", label: false %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="row column">
+  <%= form.collection_select :default_locale, localized_locales(current_organization.available_locales), :id, :name %>
+</div>
+
+<div class="row">
+  <div class="columns xlarge-6">
+    <%= form.text_field :reference_prefix %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="columns xlarge-6">
+    <%= form.check_box :user_groups_enabled %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="columns xlarge-6">
+    <%= form.check_box :badges_enabled %>
+  </div>
+</div>
+
+<%# begin decidim-seattle modificaton %>
+<div class="row">
+  <div class="columns xlarge-6">
+    <%= form.check_box :show_equity_composite_index %>
+  </div>
+</div>
+<%# end decidim-seattle modificaton %>
+
+<div class="row" id="welcome-notification-details">
+  <div class="columns xlarge-6">
+    <%= form.check_box :send_welcome_notification %>
+    <div class="send-welcome-notification-details">
+      <%= form.check_box :customize_welcome_notification %>
+
+      <div class="customize-welcome-notification-details">
+        <%= form.translated :text_field, :welcome_notification_subject %>
+        <%= form.translated :editor, :welcome_notification_body %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= javascript_include_tag "decidim/admin/welcome_notification.js" %>

--- a/app/views/decidim/proposals/proposals/show.html.erb
+++ b/app/views/decidim/proposals/proposals/show.html.erb
@@ -28,7 +28,7 @@
       <% if component_settings.geocoding_enabled? %>
         <%= render partial: "decidim/shared/static_map", locals: { icon_name: "proposals", geolocalizable: @proposal } %>
       <% end %>
-      <% if @proposal.equity_composite_index_percentile != nil %>
+      <% if present(@proposal).show_equity? %>
         <figure>
           <figcaption class="text-uppercase">
             <strong>
@@ -37,8 +37,7 @@
           </figcaption>
           <ul>
             <li>
-              <% equity_quintile = present(@proposal).equity_quintile %>
-              <%= t("quintile#{equity_quintile}", scope: "decidim.proposals.equity") %>
+              <%= t("quintile#{present(@proposal).equity_quintile}", scope: "decidim.proposals.equity") %>
             </li>
             <li>
               <%= t("proposal_description", scope: "decidim.proposals.equity") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -145,6 +145,8 @@ module DecidimHelsinki
       Decidim::Proposals::ProposalPresenter.send(:include, EquityQuintilePresenterExtensions)
       Decidim::Proposals::Admin::UpdateProposal.send(:include, AdminUpdateProposalEquityOverrides)
       Decidim::Proposals::Proposal.send(:include, LocationBasedEquityAssignable)
+      Decidim::Admin::OrganizationForm.send(:include, OrganizationFormExtensions)
+      Decidim::Admin::UpdateOrganization.send(:include, UpdateOrganizationOverrides)
 
       # City of Helsinki Extensions and Overrides
       # Helper extensions

--- a/config/locales/overrides/decidim-admin.en.yml
+++ b/config/locales/overrides/decidim-admin.en.yml
@@ -3,3 +3,5 @@ en:
     attributes:
       attachment:
         title: Title for image or attachment
+      organization:
+        show_equity_composite_index: Show equity index on proposals

--- a/db/migrate/20200729003849_add_show_composite_index_to_organizations.rb
+++ b/db/migrate/20200729003849_add_show_composite_index_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddShowCompositeIndexToOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_organizations, :show_equity_composite_index, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_22_230518) do
+ActiveRecord::Schema.define(version: 2020_07_29_003849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -896,6 +896,7 @@ ActiveRecord::Schema.define(version: 2020_07_22_230518) do
     t.jsonb "colors", default: {}
     t.jsonb "smtp_settings"
     t.boolean "force_users_to_authenticate_before_access_organization", default: false
+    t.boolean "show_equity_composite_index", default: true, null: false
     t.index ["host"], name: "index_decidim_organizations_on_host", unique: true
     t.index ["name"], name: "index_decidim_organizations_on_name", unique: true
   end


### PR DESCRIPTION
I added this flag to the organizations table because I saw a clear path to getting it done. In the future, we may want to remove this flag entirely or else move it within the process settings.

<img width="1279" alt="Screen Shot 2020-07-29 at 5 31 42 PM" src="https://user-images.githubusercontent.com/37423111/88867177-8b0d0100-d1c1-11ea-899d-bedd07aa3f48.png">