### PR TITLE
Fix sorting over overrides to use more modern override strategies

### DIFF
--- a/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -29,7 +29,7 @@ module Decidim
           if order_by_votes?
             detect_order("most_voted")
           else
-            "random"
+            "recent"
           end
         end
 


### PR DESCRIPTION
So the actual task was to update PR #13 to the concern pattern, but not only is it convoluted and weird to concern a concern, you do get an exception when you finally figure out how to do it:

```
  Cannot define multiple 'included' blocks for a Concern (ActiveSupport::Concern::MultipleIncludedBlocks)
```

New plan! Let's at least mark the areas we overrode, and while I was in there, I realized that the code in there was from decidim-proposals 0.21 and not 0.19 like it was supposed to be so I rolled that back. When I originally overrode it, I must have pulled the code from the web.