### PR TITLE
Fix: Visiting a process's meetings or projects tab is throwing exceptions

### DIFF
--- a/app/cells/decidim/tags_cell.rb
+++ b/app/cells/decidim/tags_cell.rb
@@ -66,7 +66,9 @@ module Decidim
     end
 
     def equity?
-      current_organization.show_equity_composite_index? && model.equity_composite_index_percentile != nil
+       current_organization.show_equity_composite_index? &&
+         model.has_attribute?(:equity_composite_index_percentile) && 
+         model.equity_composite_index_percentile != nil
     end
 
     def equity_name


### PR DESCRIPTION
This is related to the recent tags_cell work where the code was expecting equity attributes for non-proposal models. Turns out tags_cell is used in a bunch of places, so I put a guard in.