### PR TITLE
Add Google, Facebook, and Twitter sign-on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ public/uploads
 .graphqlconfig
 schema.json
 app/assets/javascripts/decidim/comments/bundle.js.map
+
+# Local dev secrets
+config/heroku_env.rb

--- a/README.md
+++ b/README.md
@@ -163,4 +163,19 @@ the comment in `decidim.rb` when this issue is resolved.
 
 ### Social network authentication
 
-Decidim supports single sign-on with Google, Facebook, Twitter, etc, but [it needs to be configured](https://github.com/decidim/decidim/blob/master/docs/services/social_providers.md).
+Decidim supports single sign-on with [a variety of social providers](https://github.com/decidim/decidim/blob/master/docs/services/social_providers.md) out of the box. Seattle currently has Google, Facebook, and Twitter login enabled (as defined in `secrets.yml`).
+
+The associated API keys for these services are stored in Heroku environment variables. 
+
+#### Local testing
+
+If you want to test SSO locally, you'll need to generate your own credentials. The [Decidim docs](https://github.com/decidim/decidim/blob/master/docs/services/social_providers.md) will walk you through the process of creating those.
+
+Once generated, copy the correct ENV variable name from `secrets.yml` and place the API key in  `config/heroku_env.rb`. For example:
+
+```
+ENV["OMNIAUTH_FACEBOOK_APP_ID"] = 'key'
+ENV["OMNIAUTH_FACEBOOK_APP_SECRET"] = 'secret'
+```
+
+Note: when creating Twitter OAuth credentials, make sure to list http://localhost:3000/users/auth/twitter/callback as a Callback URL.

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,10 @@ require_relative "boot"
 require "rails/all"
 require "cldr"
 
+# add local environment variables
+# http://blog.leshill.org/blog/2010/11/02/heroku-environment-variables.html
+load(File.expand_path('../heroku_env.rb', __FILE__))
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,18 +11,19 @@
 # if you're sharing your code publicly.
 
 default: &default
+  # docs at https://github.com/decidim/decidim/blob/master/docs/services/social_providers.md
   omniauth:
     facebook:
       # It must be a boolean. Remember ENV variables doesn't support booleans.
-      enabled: false
+      enabled: true
       app_id: <%= ENV["OMNIAUTH_FACEBOOK_APP_ID"] %>
       app_secret: <%= ENV["OMNIAUTH_FACEBOOK_APP_SECRET"] %>
     twitter:
-      enabled: false
+      enabled: true
       api_key: <%= ENV["OMNIAUTH_TWITTER_API_KEY"] %>
       api_secret: <%= ENV["OMNIAUTH_TWITTER_API_SECRET"] %>
     google_oauth2:
-      enabled: false
+      enabled: true
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
   geocoder:

--- a/script/dev-setup
+++ b/script/dev-setup
@@ -58,4 +58,13 @@ bundle install
 info "Creating the database, migrating, installing seed data (if necessary)"
 bin/rails db:create db:migrate db:seed_if_necessary
 
+info "Creating heroku_env.rb file to store local credentials (if necessary)"
+FILE="$DIR"/config/heroku_env.rb
+if [ ! -f "$FILE" ]; then
+    echo "# This file contains the ENV vars necessary to run the app locally." >> $FILE
+    echo "# Some of these values are sensitive, and some are developer specific." >> $FILE
+    echo "#" >> $FILE
+    echo "# DO NOT CHECK THIS FILE INTO VERSION CONTROL!" >> $FILE
+fi
+
 echo -e "${GREEN}>> You're all set up!${DEFAULT}"


### PR DESCRIPTION
This PR also adds the ability to specify local dev credentials for the values in `secrets.yml`.

I'm unsure if we should only enable social media sign-ons for the staging and production environments by default, as having SSO on for local dev environments requires a bit of legwork to get credentials. Thoughts welcome.