### PR TITLE
Initialize Heroku config file before it is needed

### DIFF
--- a/script/dev-setup
+++ b/script/dev-setup
@@ -55,9 +55,6 @@ fi
 info "Install gems (if necessary)"
 bundle install
 
-info "Creating the database, migrating, installing seed data (if necessary)"
-bin/rails db:create db:migrate db:seed_if_necessary
-
 info "Creating heroku_env.rb file to store local credentials (if necessary)"
 FILE="$DIR"/config/heroku_env.rb
 if [ ! -f "$FILE" ]; then
@@ -66,5 +63,8 @@ if [ ! -f "$FILE" ]; then
     echo "#" >> $FILE
     echo "# DO NOT CHECK THIS FILE INTO VERSION CONTROL!" >> $FILE
 fi
+
+info "Creating the database, migrating, installing seed data (if necessary)"
+bin/rails db:create db:migrate db:seed_if_necessary
 
 echo -e "${GREEN}>> You're all set up!${DEFAULT}"


### PR DESCRIPTION
A dependency was added which requires the presence of a heroku config
file when the app is initialized, [as part of adding SSO](https://github.com/King-County-Equity-Now/decidim-seattle/pull/40/files#diff-b1fe55db50c712fef0673345e5b9c0d9).

This just inits the file before it before it is needed by bin/rails.
Without this file, the scripts/dev-setup throws an exception:

```
>> Creating the database, migrating, installing seed data (if necessary)
rails aborted!
LoadError: cannot load such file -- /Users/mshenfield/Code/decidim-seattle/config/heroku_env.rb
/Users/mshenfield/Code/decidim-seattle/config/application.rb:10:in `load'
/Users/mshenfield/Code/decidim-seattle/config/application.rb:10:in `<top (required)>'
/Users/mshenfield/Code/decidim-seattle/Rakefile:6:in `require_relative'
/Users/mshenfield/Code/decidim-seattle/Rakefile:6:in `<top (required)>'
bin/rails:6:in `require'
bin/rails:6:in `<main>'
(See full trace by running task with --trace)
```