### PR TITLE
Seed database in separate bin/rails call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ public/uploads
 
 # Ignore local environment variables
 /.rbenv-vars
-/config/heroku_env.rb
 
 # Ignore webpack stuff
 /webpack.report.html

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ public/uploads
 
 # Ignore local environment variables
 /.rbenv-vars
+/config/heroku_env.rb
 
 # Ignore webpack stuff
 /webpack.report.html

--- a/script/dev-setup
+++ b/script/dev-setup
@@ -56,6 +56,8 @@ info "Install gems (if necessary)"
 bundle install
 
 info "Creating the database, migrating, installing seed data (if necessary)"
-bin/rails db:create db:migrate db:seed_if_necessary
+bin/rails db:create db:migrate
+# Run in a separate command to avoid https://github.com/rails/rails/issues/29112
+bin/rails db:seed_if_necessary
 
 echo -e "${GREEN}>> You're all set up!${DEFAULT}"


### PR DESCRIPTION
Splitting out seeding the database into a separate call should avoid rails/rails#29112, which we've all hit while setting things up (e.g. https://trello.com/c/etvCLqWp)
