### PR TITLE
Fix homepage button sizes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 
 @import 'decidim';
 @import 'helsinki';
+@import 'font-awesome';
 
 // Foundation override
 .callout{

--- a/app/cells/decidim/content_blocks/equity/show.erb
+++ b/app/cells/decidim/content_blocks/equity/show.erb
@@ -9,5 +9,10 @@
   </div>
   <div class="row" id="equity-learn-more">
     <div class="columns small-centered small-10 smallmedium-8 medium-6 large-4">
-        <%= link_to t("button_title", scope: "decidim.content_blocks.equity"), target: "_blank", "https://www.seattle.gov/rsji", class: "button expanded hollow button--sc home-section__cta" %>  </div>
+        <%= link_to "https://www.seattle.gov/rsji", target: "_blank", class: "button expanded hollow button--sc" do %>
+          <%= t("button_title", scope: "decidim.content_blocks.equity") %>
+          <i class="fa fa-external-link" style="vertical-align: text-bottom;"></i>
+        <% end %>
+    </div>
+  </div>
 </section>

--- a/app/cells/decidim/content_blocks/equity/show.erb
+++ b/app/cells/decidim/content_blocks/equity/show.erb
@@ -1,18 +1,20 @@
 <section class='extended home-section'>
-  <div class="row" id="equity-content-block">
-    <h3 class="h2 section-heading text-center"><%= t("title", scope: "decidim.content_blocks.equity") %></h3>
-    <div class="row section">
-        <div class="columns small-centered small-10 smallmedium-8 medium-8 large-8">
-            <p><%= t("subtitle", scope: "decidim.content_blocks.equity") %></p>
-        </div>
+  <div class="wrapper-home">
+    <div class="row" id="equity-content-block">
+      <h3 class="h2 section-heading text-center"><%= t("title", scope: "decidim.content_blocks.equity") %></h3>
+      <div class="row section">
+          <div class="columns small-centered small-10 smallmedium-8 medium-8 large-8">
+              <p><%= t("subtitle", scope: "decidim.content_blocks.equity") %></p>
+          </div>
+      </div>
     </div>
-  </div>
-  <div class="row" id="equity-learn-more">
-    <div class="columns small-centered small-10 smallmedium-8 medium-6 large-4">
-        <%= link_to "https://www.seattle.gov/rsji", target: "_blank", class: "button expanded hollow button--sc" do %>
-          <%= t("button_title", scope: "decidim.content_blocks.equity") %>
-          <i class="fa fa-external-link" style="vertical-align: text-bottom;"></i>
-        <% end %>
+    <div class="row" id="equity-learn-more">
+      <div class="columns small-centered small-10 smallmedium-8 medium-6 large-4">
+          <%= link_to "https://www.seattle.gov/rsji", target: "_blank", class: "button expanded hollow button--sc" do %>
+            <%= t("button_title", scope: "decidim.content_blocks.equity") %>
+            <i class="fa fa-external-link" style="vertical-align: text-bottom;"></i>
+          <% end %>
+      </div>
     </div>
   </div>
 </section>

--- a/app/cells/decidim/content_blocks/equity/show.erb
+++ b/app/cells/decidim/content_blocks/equity/show.erb
@@ -8,7 +8,6 @@
     </div>
   </div>
   <div class="row" id="equity-learn-more">
-  <div class="columns small-centered small-12 smallmedium-8 medium-6 large-4">
-      <%= link_to t("button_title", scope: "decidim.content_blocks.equity"), "https://www.seattle.gov/rsji", class: "button expanded hollow button--sc home-section__cta" %>
-  </div>
+    <div class="columns small-centered small-10 smallmedium-8 medium-6 large-4">
+        <%= link_to t("button_title", scope: "decidim.content_blocks.equity"), "https://www.seattle.gov/rsji", class: "button expanded hollow button--sc home-section__cta" %>  </div>
 </section>

--- a/app/cells/decidim/content_blocks/equity/show.erb
+++ b/app/cells/decidim/content_blocks/equity/show.erb
@@ -9,5 +9,5 @@
   </div>
   <div class="row" id="equity-learn-more">
     <div class="columns small-centered small-10 smallmedium-8 medium-6 large-4">
-        <%= link_to t("button_title", scope: "decidim.content_blocks.equity"), "https://www.seattle.gov/rsji", class: "button expanded hollow button--sc home-section__cta" %>  </div>
+        <%= link_to t("button_title", scope: "decidim.content_blocks.equity"), target: "_blank", "https://www.seattle.gov/rsji", class: "button expanded hollow button--sc home-section__cta" %>  </div>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
         name: Equity
         title: How we bring equity into focus
         subtitle: The Racial and Social Equity Index combines information on race, ethnicity, and related demographics with data on socioeconomic and health disadvantages to identify where priority populations make up relatively large proportions of neighborhood residents.
-        button_title: Learn More
+        button_title: Learn more
     pages:
       home:
         statistics:


### PR DESCRIPTION
Tidied up the equity button on the homepage to match the "More info" button directly above, add an external link indicator, and tighten up the spacing. As an added bonus, we can use Font Awesome icons now!

Before:
![image](https://user-images.githubusercontent.com/3937986/92667255-45634e00-f2c0-11ea-8085-4df7f5ef8cdc.png)

After:
![image](https://user-images.githubusercontent.com/3937986/92667535-0aade580-f2c1-11ea-80cf-3333367a7f93.png)