### PR TITLE
enable web console in Docker

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,4 +71,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # display web console on Dockerized site
+  config.web_console.whitelisted_ips = '172.17.0.1'
 end


### PR DESCRIPTION
Add the IP necessary to enable the web console in Docker.

@rnewton when you have a chance could you confirm this IP will be the same for every dev who sets the project up?