### PR TITLE
add equity explainer tooltip to proposal cards

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,8 @@
 html.js .hide-on-load{
   display: none;
 }
+
+// Make equity info tooltips easier to read
+.tooltip {
+  max-width: 500px;
+}

--- a/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -310,6 +310,10 @@ $datetime-bg: $primary;
   font-weight: 600;
 }
 
+.equity_info {
+  font-weight: normal;
+}
+
 .card .tags .category{
   font-size: 16px;
   line-height: 24px;

--- a/app/cells/decidim/tags/equity.erb
+++ b/app/cells/decidim/tags/equity.erb
@@ -1,4 +1,6 @@
 <span class="equity_score"><%= equity_name %></span>
 |
-<a href="<%= proposal_path %>"><%= t("card_more_info", scope: "decidim.proposals.equity") %></a>
+<span tabindex="0" aria-haspopup="true" data-tooltip="true" data-keep-on-hover="true" data-click-open="false" data-container="body" data-disable-hover="false" class="has-tip equity_info" title="<%= t("proposal_description", scope: "decidim.proposals.equity") %>">
+  <%= t("card_more_info", scope: "decidim.proposals.equity") %>
+</span>
 <br />


### PR DESCRIPTION
Technically ready for merging, but I'd like to add some extra styling first.