### PR TITLE
Decode special chars on cards

### DIFF
--- a/app/cells/decidim/plans/plan_m_cell.rb
+++ b/app/cells/decidim/plans/plan_m_cell.rb
@@ -40,6 +40,7 @@ module Decidim
 
       def description
         model_body = strip_tags(body)
+        model_body = CGI.unescapeHTML(model_body)
 
         if options[:full_description]
           model_body.gsub(/\n/, "<br>")

--- a/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -47,7 +47,8 @@ module Decidim
       def description
         model_body = present(model).body
         model_body = strip_tags(model_body)
-
+        model_body = CGI.unescapeHTML(model_body)
+        
         if options[:full_description]
           model_body.gsub(/\n/, "<br>")
         else

--- a/app/views/decidim/plans/plans/_linked_plans.html.erb
+++ b/app/views/decidim/plans/plans/_linked_plans.html.erb
@@ -1,0 +1,32 @@
+<div class="card card--action card--list">
+  <% resources.each do |plan| %>
+    <div class="card--list__item">
+      <div class="card--list__text">
+        <%= link_to resource_locator(plan).path do %>
+          <%= icon "proposals", class: "card--list__icon", remove_icon_class: true %>
+        <% end %>
+        <div>
+          <%= link_to resource_locator(plan).path, class: "card__link" do %>
+            <h5 class="card--list__heading"><%= present(plan).title %></h5>
+          <% end %>
+          <% present(plan) do |plan| %>
+            <div class="author">
+              <span class="author__avatar">
+                <%= image_tag plan.author.avatar_url %>
+              </span>
+              <span class="author__name">
+                <strong><%= plan.author.name %></strong>
+                <%= plan.author.nickname %>
+              </span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="card--list__data">
+        <span class="card--list__data__number">
+          <%= plan.authors.count %>
+        </span> <%= t(".plan_authors", count: plan.authors.count) %>
+      </div>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
Fixed bug that would display "`&amp;`" instead of "&" in proposal cards, plan cards, and "Related Plans" links on individual proposal pages.